### PR TITLE
README suggestions/fix and added defaults to the portal group variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ SAML response.
 
 This codebase contains all the roles/playbooks and templates to
 configure a COmanage VMs.  The target Linux distribution for COmanage
-server is Ubuntu Server 16.04
+server is Ubuntu Server 16.04. Target machines should have a user named 'ubuntu'
+with sudo powers and the root user should have passwordless access to MySQL.
 
 Machines are provisioned as follows:
 
@@ -26,7 +27,7 @@ inventory. See the `inventory` directory. The with this example
 inventory, the above command will become:
 
 ```
-ansible-playbook -i inventory/example/hosts comanage.yml
+ansible-playbook -i inventories/example/hosts comanage.yml
 ```
 
 ## Example inventory

--- a/inventories/example/group_vars/portal.yml
+++ b/inventories/example/group_vars/portal.yml
@@ -1,8 +1,18 @@
 ---
-
-certificate: /etc/ssl/certs/portal.example.org.pem
-certificate_key: /etc/ssl/private/portal.example.org.key
-
 sp_protocol: https://
 sp_hostname: portal.example.org
 sp_path: registry/auth/sp
+
+certificate: "/etc/ssl/certs/{{ sp_hostname }}.pem"
+certificate_key: "/etc/ssl/private/{{ sp_hostname }}.key"
+
+comanage_version: "develop"
+given_name: "John"
+surname: "Doe"
+email_contact: "john.doe@example.org"
+organisation: "Example.com Ltd."
+subject: "/C=NL/ST=North-Holland/L=Amsterdam/O=IT/CN={{ sp_hostname }}"
+cert_days_valid: 365
+cert_key_dest: "/etc/ssl/private/{{ sp_hostname }}.key"
+cert_dest: "/etc/ssl/certs/{{ sp_hostname }}.pem"
+


### PR DESCRIPTION
Apparently, the VagrantFile sets a few default variables that have no other default setting in the group_vars or roles/defaults files (IIRC: cert_days_valid, cert_key_dest and cert_dest). 